### PR TITLE
Fix constructor interfaces to extended classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ Dependencies
 These are the minimum requirements to have phpari installed on your server:
 
 ** PHP >= 5.3.9
+
 ** Composer
+
 ** PHP OpenSSL Module to connect using SSL (wss:// uris)
 
 Additional dependencies are installed via Composer, these include:
 
 ** Reactphp   (http://reactphp.org/)
+
 ** ZF2 Logger (http://framework.zend.com/manual/2.0/en/modules/zend.log.overview.html)
 
 Installation
@@ -47,7 +50,7 @@ echo "Ending ARI Connection\n";
 
 ```
 
-The output should resemble the followiong:
+The output should resemble the following:
 
 ```
 [root@ari agi-bin]# php test.php
@@ -56,6 +59,6 @@ Active Channels: []
 Ending ARI Connection
 ```
 
-Reporiting Issues
+Reporting Issues
 --------------------
 Please report issues directly via the Github project page.

--- a/src/interfaces/applications.php
+++ b/src/interfaces/applications.php
@@ -33,7 +33,6 @@ class applications // extends phpari
             if (is_null($connObject) || is_null($connObject->ariEndpoint))
                 throw new Exception("Missing PestObject or empty string", 503);
 
-
             $this->pestObject = $connObject->ariEndpoint;
 
         } catch (Exception $e) {

--- a/src/interfaces/asterisk.php
+++ b/src/interfaces/asterisk.php
@@ -26,14 +26,14 @@
 class asterisk // extends phpari
 {
 
-    function __construct($pestObject = NULL)
+    function __construct($connObject = null)
     {
         try {
 
-            if (is_null($pestObject))
+            if (is_null($connObject) || is_null($connObject->ariEndpoint))
                 throw new Exception("Missing PestObject or empty string", 503);
 
-            $this->pestObject = $pestObject;
+            $this->pestObject = $connObject->ariEndpoint;
 
         } catch (Exception $e) {
             die("Exception raised: " . $e->getMessage() . "\nFile: " . $e->getFile() . "\nLine: " . $e->getLine());

--- a/src/interfaces/bridges.php
+++ b/src/interfaces/bridges.php
@@ -25,13 +25,15 @@
  */
 class bridges // extends phpari
 {
-    function __construct($connObject = NULL)
+    function __construct($connObject = null)
     {
         try {
 
             if (is_null($connObject) || is_null($connObject->ariEndpoint))
                 throw new Exception("Missing PestObject or empty string", 503);
+
             $this->pestObject = $connObject->ariEndpoint;
+
         } catch (Exception $e) {
             die("Exception raised: " . $e->getMessage() . "\nFile: " . $e->getFile() . "\nLine: " . $e->getLine());
         }

--- a/src/interfaces/channels.php
+++ b/src/interfaces/channels.php
@@ -26,16 +26,12 @@
 class channels //extends phpari
 {
 
-    function __construct($connObject = NULL)
+    function __construct($connObject = null)
     {
         try {
 
             if (is_null($connObject) || is_null($connObject->ariEndpoint))
                 throw new Exception("Missing PestObject or empty string", 503);
-
-
-            //   print_r($pestObject);
-
 
             $this->pestObject = $connObject->ariEndpoint;
 

--- a/src/interfaces/devicestates.php
+++ b/src/interfaces/devicestates.php
@@ -25,14 +25,12 @@
 class devicestates //extends phpari
 {
 
-
     function __construct($connObject = null)
     {
         try {
 
-            if (is_null($connObject)  || is_null($connObject->ariEndpoint))
+            if (is_null($connObject) || is_null($connObject->ariEndpoint))
                 throw new Exception("Missing PestObject or empty string", 503);
-
 
             $this->pestObject = $connObject->ariEndpoint;
 

--- a/src/interfaces/endpoints.php
+++ b/src/interfaces/endpoints.php
@@ -26,13 +26,13 @@
 class endpoints //extends phpari
 {
 
-
-    function __construct($connObject = NULL)
+    function __construct($connObject = null)
     {
         try {
 
             if (is_null($connObject) || is_null($connObject->ariEndpoint))
                 throw new Exception("Missing PestObject or empty string", 503);
+
             $this->pestObject = $connObject->ariEndpoint;
 
         } catch (Exception $e) {

--- a/src/interfaces/events.php
+++ b/src/interfaces/events.php
@@ -31,7 +31,9 @@ class events // extends phpari
 
             if (is_null($connObject) || is_null($connObject->ariEndpoint))
                 throw new Exception("Missing PestObject or empty string", 503);
+
             $this->pestObject = $connObject->ariEndpoint;
+
         } catch (Exception $e) {
             die("Exception raised: " . $e->getMessage() . "\nFile: " . $e->getFile() . "\nLine: " . $e->getLine());
         }

--- a/src/interfaces/mailboxes.php
+++ b/src/interfaces/mailboxes.php
@@ -31,7 +31,9 @@ class mailboxes //extends phpari
 
             if (is_null($connObject) || is_null($connObject->ariEndpoint))
                 throw new Exception("Missing PestObject or empty string", 503);
+
             $this->pestObject = $connObject->ariEndpoint;
+
         } catch (Exception $e) {
             die("Exception raised: " . $e->getMessage() . "\nFile: " . $e->getFile() . "\nLine: " . $e->getLine());
         }

--- a/src/interfaces/recordings.php
+++ b/src/interfaces/recordings.php
@@ -27,12 +27,13 @@ class recordings //extends phpari
 {
 
 
-    function __construct($connObject = NULL)
+    function __construct($connObject = null)
     {
         try {
 
             if (is_null($connObject) || is_null($connObject->ariEndpoint))
                 throw new Exception("Missing PestObject or empty string", 503);
+
             $this->pestObject = $connObject->ariEndpoint;
 
         } catch (Exception $e) {

--- a/src/interfaces/sounds.php
+++ b/src/interfaces/sounds.php
@@ -31,13 +31,14 @@ class sounds //extends phpari
 
             if (is_null($connObject) || is_null($connObject->ariEndpoint))
                 throw new Exception("Missing PestObject or empty string", 503);
+
             $this->pestObject = $connObject->ariEndpoint;
+
         } catch (Exception $e) {
             die("Exception raised: " . $e->getMessage() . "\nFile: " . $e->getFile() . "\nLine: " . $e->getLine());
         }
     }
-
-
+    
     /**
      * GET /sounds
      * List all sounds.


### PR DESCRIPTION
Some of our interfaces were mis-implementing the __construct function. This is now updated to reflect a unified constructor for all extension classes.
