### PR TITLE
Fix null POST body in channels requests for asterisk 13.14.0

### DIFF
--- a/src/interfaces/channels.php
+++ b/src/interfaces/channels.php
@@ -330,7 +330,7 @@
                 if (is_null($channel_id))
                     throw new Exception("Channel ID not provided or is null", 503);
 
-                $result = $this->pestObject->post("/channels/" . $channel_id . "/answer", NULL);
+                $result = $this->pestObject->post("/channels/" . $channel_id . "/answer", array());
 
                 return $result;
 
@@ -375,7 +375,7 @@
                 if (is_null($channel_id))
                     throw new Exception("Channel ID not provided or is null", 503);
 
-                $result = $this->pestObject->post("/channels/" . $channel_id . "/ring", NULL);
+                $result = $this->pestObject->post("/channels/" . $channel_id . "/ring", array());
 
                 return $result;
 
@@ -628,7 +628,7 @@
                         break;
                     case "start":
                     default:
-                        $result = $this->pestObject->post("/channels/" . $channel_id . "/hold", NULL);
+                        $result = $this->pestObject->post("/channels/" . $channel_id . "/hold", array());
                         break;
                 }
 
@@ -777,7 +777,7 @@
                         break;
                     case "start":
                     default:
-                        $result = $this->pestObject->post("/channels/" . $channel_id . "/silence", NULL);
+                        $result = $this->pestObject->post("/channels/" . $channel_id . "/silence", array());
                         break;
                 }
 


### PR DESCRIPTION
Passing empty array instead of null as data for POST requests, asterisk 13.14.0 does not like null as POST body.  I checked the other interfaces and all of their POST requests have a non-null data so I believe this is the extent of the changes needed.  I tested this on 13.10.0, and as noted in issue thread https://github.com/greenfieldtech-nirs/phpari/issues/45 it is backwards compatible.

@greenfieldtech-nirs I wasn't sure if this pull request should be issued against develop instead of master, let me know if I should pull request to develop branch instead.