### PR TITLE
move configuration parsing to its own class

### DIFF
--- a/phpari.php
+++ b/phpari.php
@@ -80,12 +80,12 @@ class phpari
 	 * Returns an array containing 5 objects: WebSocket, Pest, EventLoopFactory, Logger, StasisEventHandler
 	 *
 	 */
-	public function __construct($stasisApplication = NULL, $configFile = "phpari.ini")
+	public function __construct($stasisApplication = NULL, $config = "phpari.ini")
 	{
 		try {
 
 			/* Get our configuration */
-			$this->configuration = (object)parse_ini_file($configFile, TRUE);
+			$this->configuration = new phpari_config($config);
 
 			/* Some general information */
 			$this->debug = $this->configuration->general['debug'];

--- a/phpari_config.php
+++ b/phpari_config.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * phpari - A PHP Class Library for interfacing with Asterisk(R) ARI
+ * Copyright (C) 2014  Nir Simionovich
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * Also add information on how to contact you by electronic and paper mail.
+ *
+ * Greenfield Technologies Ltd., hereby disclaims all copyright interest in
+ * the library `phpari' (a library for creating smart telephony applications)
+ * written by Nir Simionovich and its respective list of contributors.
+ */
+class phpari_config {
+
+	private $configuration = array(
+		'general' => array(
+			'logfile' => 'console',
+			'debug'   => 0,
+		),
+		'asterisk_ari' => array(
+			'username' => 'asterisk',
+			'password' => 'asterisk',
+			'host'     => '127.0.0.1',
+			'port'     => '8088',
+			'endpoint' => '/ari',
+			'transport' => 'ws',
+		),
+		'asterisk_manager' => array(
+			'username' => 'amiuser',
+			'password' => 'amipassword',
+			'host'     => '127.0.0.1',
+			'port'     => '5038'
+		),
+	);
+
+	public function __construct($config = 'phpari.ini') {
+		if (is_array($config)) {
+			$this->config_merge($config);
+			return;
+		}
+		
+		// in case we read a fle for initialization, its easy
+		if (($ini = parse_ini_file($configFile, TRUE)) === false)
+			throw new Exception("Invald INI file provided: '$config'");
+		$this->config_merge($ini);
+	}
+	
+	private function config_merge($config = []) {
+		foreach ($config as $section => $settings) {
+			if (array_key_exists($section, $this->configuration))
+				$this->configuration[$section] = array_merge($this->configuration[$section], $config[$section]);
+			else
+				$this->configuration[$section] = $config[$section];
+		}
+	}
+	
+	public function __get($section) {
+		return @$this->configuration[$section];
+	}
+
+}


### PR DESCRIPTION
The resulting config file has defaults set up in a way that easy to manage, supports sending an array structure instead of a file name, and the parsing code doesn't need to be changed when adding sections and settings - as long as the INI limitations are observed, i.e. only two levels, where the first level is always an array.