### PR TITLE
callerid changed by callerId

### DIFF
--- a/examples/ChannelOriginate.php
+++ b/examples/ChannelOriginate.php
@@ -37,7 +37,7 @@
             "priority"       => 1,
             "app"            => "",
             "appArgs"        => "",
-            "callerid"       => "111",
+            "callerId"       => "111",
             "timeout"        => -1,
             "channelId"      => '324234',
             "otherChannelId" => ""

--- a/src/interfaces/channels.php
+++ b/src/interfaces/channels.php
@@ -108,7 +108,7 @@
          *      "app": (String) "The application that is subscribed to the originated channel, and passed to the Stasis
          *      application",
          *      "appArgs": (String) "The application arguments to pass to the Stasis application",
-         *      "callerid": (String) "CallerID to use when dialing the endpoint or extension",
+         *      "callerId": (String) "CallerID to use when dialing the endpoint or extension",
          *      "timeout": (Integer) "Timeout (in seconds) before giving up dialing, or -1 for no timeout",
          *      "channelId": (String) "The unique id to assign the channel on creation",
          *      "otherChannelId": (String) "The unique id to assign the second channel when using local channels"


### PR DESCRIPTION
In the channel_originate() function was changed "callerid" by "callerId" so that this parameter can be used by asterisk