### PR TITLE
Fix config file issue with "undefined variable"

### DIFF
--- a/phpari_config.php
+++ b/phpari_config.php
@@ -52,8 +52,8 @@ class phpari_config {
 			return;
 		}
 		
-		// in case we read a fle for initialization, its easy
-		if (($ini = parse_ini_file($configFile, TRUE)) === false)
+		// in case we read a file for initialization, its easy
+		if (($ini = parse_ini_file($config, TRUE)) === false)
 			throw new Exception("Invald INI file provided: '$config'");
 		$this->config_merge($ini);
 	}


### PR DESCRIPTION
Change $configFile to $config as it was using the wrong variable causing an undefined variable error when using a INI file.